### PR TITLE
Replaced instances of 3D Analyst with equivalent Spatial Analyst function

### DIFF
--- a/Scripts/GeMS_ProjectCrossSectionData.py
+++ b/Scripts/GeMS_ProjectCrossSectionData.py
@@ -218,7 +218,7 @@ def locateEventTable(
 
     if not desc.hasZ:
         addMsgAndPrint("      adding Z values")
-        arcpy.AddSurfaceInformation_3d(pts, dem, zType, "LINEAR")
+        arcpy.da.AddSurfaceInformation(pts, dem, zType, "LINEAR")
 
     ## working around bug in LocateFeaturesAlongRoutes
     # add special field for duplicate detection
@@ -303,9 +303,9 @@ addMsgAndPrint("  Scratch directory is " + scratch)
 arcpy.env.overwriteOutput = True
 
 try:
-    arcpy.CheckOutExtension("3D")
+    arcpy.CheckOutExtension("Spatial")
 except:
-    addMsgAndPrint("\nCannot check out 3D-analyst extension.")
+    addMsgAndPrint("\nCannot check out Spatial Analyst extension.")
     sys.exit()
 
 ## Checking section line
@@ -367,7 +367,7 @@ else:
     # Add Z values
     addMsgAndPrint("    getting elevation values for " + shortName(tempXsLine))
     Zline = arcpy.CreateScratchName("xx", outFdsTag + "_Z", "FeatureClass", scratch)
-    arcpy.InterpolateShape_3d(dem, tempXsLine, Zline)
+    arcpy.da.InterpolateShape(dem, tempXsLine, Zline)
     # Add M values
     addMsgAndPrint("    measuring " + shortName(Zline))
     ZMline = arcpy.CreateScratchName("xx", outFdsTag + "_ZM", "FeatureClass", scratch)
@@ -679,7 +679,7 @@ for polyFC in polyFCs:
             testAndDelete(f)
     del inRows, outRows
 
-arcpy.CheckInExtension("3D")
+arcpy.CheckInExtension("Spatial")
 if not saveIntermediate:
     addMsgAndPrint("\n  Deleting intermediate data sets")
     for fc in tempXsLine, ZMline, Zline, tempBuffer:


### PR DESCRIPTION
The 3D Analyst-dependent methods in this tool are also offered in the Spatial Analyst extension. Although both are add-ons to ArcGIS, our assumption is that Spatial Analyst is more commonly used because of its utility for many traditional 2d map geoprocessing processes.

Here's a comparison matrix for the methods in both extensions.

| Method | 3D Help Page | Spatial Help Page |
| - | - | - |
| AddSurfaceInformation | [Add Surface Information (3D Analyst)](https://pro.arcgis.com/en/pro-app/latest/tool-reference/3d-analyst/add-surface-information.htm) | [Add Surface Information (Spatial Analyst)](https://pro.arcgis.com/en/pro-app/latest/tool-reference/spatial-analyst/add-surface-information.htm) |
| InterpolateShape | [Interpolate Shape (3D Analyst)](https://pro.arcgis.com/en/pro-app/latest/tool-reference/3d-analyst/interpolate-shape.htm) | [Interpolate Shape (Spatial Analyst)](https://pro.arcgis.com/en/pro-app/latest/tool-reference/spatial-analyst/interpolate-shape.htm) |

Help pages for Interpolate Shape in particular look identical! Based on the [Spatial Analyst extension's update history](https://pro.arcgis.com/en/pro-app/latest/tool-reference/spatial-analyst/spatial-analyst-toolbox-history-pro.htm), I assume these tools were present only in the 3D analyst extension when the original GeMS_ProjectCrossSectionData.py was written, and were later added to Spatial Analyst.

We did some minor testing and produced identical results between 3D and Spatial versions. We did not test every scenario as the Esri methods seem to be identical.